### PR TITLE
Fix Rust toolchain setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,10 +3,21 @@
 ---
 tasks:
   - init: |
+      # Install mob tool.
       curl -sL install.mob.sh | sudo sh
-      rustup install stable
-      rustup component add rustfmt clippy rust-src rust-docs
-      rustup component add rls rust-analysis llvm-tools-preview
+      
+      # GitPod's rustup wrapper seems not to work with current
+      # versions of rustup. Disable wrapper and unset CARGO_HOME
+      # while installing the current Rust stable toolchain
+      # and additional components.
+      mv ~/.cargo/bin/rustup ~/.cargo/bin/rustup.script
+      mv ~/.cargo/bin/rustup.main ~/.cargo/bin/rustup
+      CARGO_HOME= rustup toolchain install stable
+      CARGO_HOME= rustup component add rust-docs llvm-tools-preview
+      mv ~/.cargo/bin/rustup ~/.cargo/bin/rustup.main
+      mv ~/.cargo/bin/rustup.script ~/.cargo/bin/rustup
+
+      # Build workspace.
       cargo build
 
 vscode:


### PR DESCRIPTION
This workaround should fix out setup issue for now.

Changes:
- GitPod's rustup wrapper seems not to work with current versions of
  rustup. Disable wrapper and unset CARGO_HOME while installing the
  current Rust stable toolchain and additional components.
- Remove components from "component add" command that are already
  installed in the current GitPod image.

Run GitPod on this branch:
https://gitpod.io/#https://github.com/mob-programming-meetup/the-rustic-mob/tree/gitpod-fix
